### PR TITLE
add start to RangeDecoder

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -47,7 +47,8 @@ int main() {
 
     // Decode
     auto decoded = std::vector<int>();
-    auto decoder = rangecoder::RangeDecoder(bytes_queue);
+    auto decoder = rangecoder::RangeDecoder();
+    decoder.start(bytes_queue);
     for (int i = 0; i < sequence_of_data.size(); i++){
         decoded.push_back(decoder.decode(pmodel));
     }

--- a/rangecoder.h
+++ b/rangecoder.h
@@ -109,6 +109,16 @@ namespace rangecoder
         }
 
     protected:
+        void lower_bound(const range_t lower_bound)
+        {
+            m_lower_bound = lower_bound;
+        };
+
+        void range(const range_t range)
+        {
+            m_range = range;
+        };
+
         auto lower_bound() const -> range_t
         {
             return m_lower_bound;
@@ -219,8 +229,9 @@ namespace rangecoder
         void start(std::queue<byte_t> bytes)
         {
             m_bytes = std::move(bytes);
-        m_lower_bound = 0;
-        m_range = std::numeric_limits<range_t>::max();
+            lower_bound(0);
+            range(std::numeric_limits<range_t>::max());
+
             for (auto i = 0; i < 8; i++)
             {
                 shift_byte_buffer();

--- a/rangecoder.h
+++ b/rangecoder.h
@@ -109,13 +109,12 @@ namespace rangecoder
         }
 
     protected:
-        auto
-        lower_bound() -> range_t const
+        auto lower_bound() const -> range_t
         {
             return m_lower_bound;
         };
 
-        auto range() -> range_t const
+        auto range() const -> range_t
         {
             return m_range;
         };
@@ -152,7 +151,7 @@ namespace rangecoder
             }
         };
 
-        auto upper_bound() -> uint64_t const
+        auto upper_bound() const -> uint64_t
         {
             return m_lower_bound + m_range;
         };
@@ -253,7 +252,7 @@ namespace rangecoder
 
     private:
         // binary search encoded index
-        auto binary_search_encoded_index(PModel &pmodel) -> const int
+        auto binary_search_encoded_index(PModel &pmodel) const -> int
         {
             auto left = pmodel.min_index();
             auto right = pmodel.max_index();

--- a/rangecoder.h
+++ b/rangecoder.h
@@ -217,11 +217,9 @@ namespace rangecoder
     class RangeDecoder : RangeCoder
     {
     public:
-        RangeDecoder() = delete;
-
-        RangeDecoder(std::queue<byte_t> bytes)
+        void start(std::queue<byte_t> bytes)
         {
-            m_bytes = bytes;
+            m_bytes = std::move(bytes);
 
             for (auto i = 0; i < 8; i++)
             {

--- a/rangecoder.h
+++ b/rangecoder.h
@@ -220,7 +220,8 @@ namespace rangecoder
         void start(std::queue<byte_t> bytes)
         {
             m_bytes = std::move(bytes);
-
+        m_lower_bound = 0;
+        m_range = std::numeric_limits<range_t>::max();
             for (auto i = 0; i < 8; i++)
             {
                 shift_byte_buffer();

--- a/test/rangecodertest.cpp
+++ b/test/rangecodertest.cpp
@@ -92,7 +92,8 @@ auto helper_enc_dec_freqtable(std::vector<int> &data) -> std::vector<int>
         que.push(byte);
     }
     std::cout << "decode" << std::endl;
-    auto dec = rangecoder::RangeDecoder(que);
+    auto dec = rangecoder::RangeDecoder();
+    dec.start(que);
     auto decoded = std::vector<int>();
     for (int i = 0; i < data.size(); i++)
     {
@@ -138,7 +139,8 @@ auto test_uniform(std::vector<int> &data) -> std::vector<int>
         que.push(byte);
     }
     std::cout << "decode" << std::endl;
-    auto dec = rangecoder::RangeDecoder(que);
+    auto dec = rangecoder::RangeDecoder();
+    dec.start(que);
     auto decoded = std::vector<int>();
     for (int i = 0; i < data.size(); i++)
     {


### PR DESCRIPTION
I propose an implementation of `start` that can be executed at any time instead of removing the RangeDecoder's constructor.

The motivation for the suggestion is that the `bytes` may not be ready before the constructor is called.

