### PR TITLE
simplify update_param

### DIFF
--- a/rangecoder.h
+++ b/rangecoder.h
@@ -44,7 +44,7 @@ namespace rangecoder
             return min_index() <= index && index <= max_index();
         }
     };
-      
+
     enum RangeCoderVerbose {
         SILENT = false,
         VERBOSE = true,
@@ -97,6 +97,7 @@ namespace rangecoder
                     std::cout << "  range, lower bound updated" << std::endl;
                     print_status();
                 }
+
                 while (is_no_carry_expansion_needed())
                 {
                     f(do_no_carry_expansion<RANGECODER_VERBOSE>());
@@ -109,7 +110,7 @@ namespace rangecoder
                 }
                 if constexpr (RANGECODER_VERBOSE)
                 {
-                    std::cout << "  total: " << bytes.size() << " byte shifted" << std::endl;
+                    std::cout << "  total: " << num_bytes << " byte shifted" << std::endl;
                 }
                 return num_bytes;
             };

--- a/rangecoder.h
+++ b/rangecoder.h
@@ -100,7 +100,7 @@ namespace rangecoder
                     num_bytes++;
                 }
 #ifdef RANGECODER_VERBOSE
-                std::cout << "  " << bytes.size() << " byte shifted" << std::endl;
+                std::cout << "  " << num_bytes << " byte shifted" << std::endl;
 #endif
                 return num_bytes;
             };

--- a/rangecoder.h
+++ b/rangecoder.h
@@ -16,6 +16,34 @@ namespace rangecoder
     using range_t = uint64_t;
     using byte_t = uint8_t;
 
+    class PModel
+    {
+    public:
+        // Accumulated frequency of index, i.e. sum of frequency of range [min_index, index).
+        virtual range_t cum_freq(int index) const = 0;
+
+        // Frequency of index
+        virtual range_t c_freq(int index) const = 0;
+
+        range_t total_freq() const
+        {
+            return cum_freq(max_index()) + c_freq(max_index());
+        };
+
+        // Returns min index, the first valid index.
+        // All index 'i', that satisfy 'pmodel.min_index() <= i <= pmodel.max_index()' must be valid index.
+        virtual int min_index() const = 0;
+
+        // Returns max index, the last valid index.
+        // All index 'i', that satisfy 'pmodel.min_index() <= i <= pmodel.max_index()' must be valid index.
+        virtual int max_index() const = 0;
+
+        bool index_is_valid(int index)
+        {
+            return min_index() <= index && index <= max_index();
+        }
+    };
+
     namespace local
     {
         const auto TOP8 = range_t(1) << (64 - 8);
@@ -157,34 +185,6 @@ namespace rangecoder
             uint64_t m_range;
         };
     }// namespace local
-
-    class PModel
-    {
-    public:
-        // Accumulated frequency of index, i.e. sum of frequency of range [min_index, index).
-        virtual range_t cum_freq(int index) const = 0;
-
-        // Frequency of index
-        virtual range_t c_freq(int index) const = 0;
-
-        range_t total_freq() const
-        {
-            return cum_freq(max_index()) + c_freq(max_index());
-        };
-
-        // Returns min index, the first valid index.
-        // All index 'i', that satisfy 'pmodel.min_index() <= i <= pmodel.max_index()' must be valid index.
-        virtual int min_index() const = 0;
-
-        // Returns max index, the last valid index.
-        // All index 'i', that satisfy 'pmodel.min_index() <= i <= pmodel.max_index()' must be valid index.
-        virtual int max_index() const = 0;
-
-        bool index_is_valid(int index)
-        {
-            return min_index() <= index && index <= max_index();
-        }
-    };
 
     class RangeEncoder : local::RangeCoder
     {


### PR DESCRIPTION
I have two concerns with the vector `bytes = std::vector<byte_t>()` defined inside `update_param`:

  1. In Encoder, I want to push_back the element directly to the vector `m_bytes` to avoid overhead.
  
  2. In Decoder, vector `bytes` are not required.

Furthermore, the argument parameters of `update_param` can be simplified by passing a reference of PModel.