### PR TITLE
change the order of inclusion in test

### DIFF
--- a/test/rangecodertest.cpp
+++ b/test/rangecodertest.cpp
@@ -1,3 +1,5 @@
+#include "../rangecoder.h"
+
 #include <algorithm>
 #include <iostream>
 #include <random>
@@ -5,8 +7,6 @@
 #include <string>
 
 #include <gtest/gtest.h>
-
-#include "../rangecoder.h"
 
 class FreqTable : public rangecoder::PModel
 {


### PR DESCRIPTION
To prevent mistakes like #28  , `rangecoder.h` should be included first in test.